### PR TITLE
Switch reactivate user to only need an ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start-with-tons-of-crossings": "yarn run local-drop-rebuild-with-tons-of-crossings;yarn run start-express-server",
     "rebuild-and-deploy": "yarn run drop-data;yarn run populate-schema;yarn run populate-data;yarn run build-schema;sls deploy -v",
     "rebuild-and-deploy-with-tons-of-crossings": "yarn run drop-data;yarn run populate-schema;yarn run add-tons-of-crossings-to-db;yarn run build-schema;sls deploy -v",
-    "test": "react-scripts test",
+    "test": "JWT_SECRET='insecure' react-scripts test",
     "test-on-aws": "USE_AWS_ENDPOINT=true react-scripts test",
     "populate-schema": "psql $npm_config_PGCON -f ./populateDB/schema.sql",
     "populate-local-schema": "psql $npm_package_config_PGLOCALCON -f ./populateDB/schema.sql",

--- a/populateDB/schema.sql
+++ b/populateDB/schema.sql
@@ -279,17 +279,19 @@ comment on function floods.deactivate_user(integer) is 'Deactivates a user and d
 
 -- Create function to reactivate users
 create function floods.reactivate_user(
-  user_id integer,
-  email text,
-  password text,
-  role text
+  user_id integer
 ) returns floods.user as $$
 declare
   deactivated_user floods.user;
+  password text;
   floods_user floods.user;
 begin
   -- Get the deactivated user
   select * from floods.user where id = user_id into deactivated_user;
+
+  -- Generate a random password
+  select array_to_string(array(select chr((48 + round(random() * 59)) :: integer) 
+    from generate_series(1,32)), '') into password;
 
   -- If we aren't a super admin
   if current_setting('jwt.claims.role') != 'floods_super_admin' then
@@ -310,7 +312,7 @@ begin
   end if;
 
   insert into floods_private.user_account (user_id, email, role, community_id, password_hash) values
-    (deactivated_user.id, email, role, deactivated_user.community_id, crypt(password, gen_salt('bf')));
+    (deactivated_user.id, deactivated_user.email_address, deactivated_user.role, deactivated_user.community_id, crypt(password, gen_salt('bf')));
 
   update floods.user
     set active = true
@@ -321,7 +323,7 @@ begin
 end;
 $$ language plpgsql strict security definer;
 
-comment on function floods.reactivate_user(integer, text, text, text) is 'Reactivates a user and creates an account.';
+comment on function floods.reactivate_user(integer) is 'Reactivates a user and creates an account.';
 
 -- Create function to search crossings
 create function floods.search_crossings(
@@ -1059,7 +1061,7 @@ grant execute on function floods.deactivate_user(integer) to floods_community_ed
 
 -- Allow community admins and up to reactivate users
 -- NOTE: Extra logic around permissions in function
-grant execute on function floods.reactivate_user(integer, text, text, text) to floods_community_admin;
+grant execute on function floods.reactivate_user(integer) to floods_community_admin;
 
 -- Allow community editors and up to get the current logged in user
 grant execute on function floods.current_user() to floods_community_editor;

--- a/populateDB/schema.sql
+++ b/populateDB/schema.sql
@@ -302,7 +302,7 @@ begin
         raise exception 'Community administrators can only reactivate editors in communities they administrate';
       end if;
       -- and we're trying to add someone other than a community editor
-      if role != 'floods_community_editor' then
+      if deactivated_user.role != 'floods_community_editor' then
         raise exception 'Community administrators can only reactivate editors in communities they administrate';
       end if;
     -- all other roles shouldn't be here

--- a/src/community.admin.deactivate.reactivate.user.test.js
+++ b/src/community.admin.deactivate.reactivate.user.test.js
@@ -326,12 +326,9 @@ describe('When registering, deactivating, and reactivating a user as a community
     it('should reactivate the user', async () => {
       const response = await lokka.send(
         `
-        mutation($userId:Int!, $email:String!) {
+        mutation($userId:Int!) {
           reactivateUser(input: {
-            userId: $userId,
-            email: $email
-            password: "texasfloods"
-            role: "floods_community_editor"
+            userId: $userId
           }) {
             user {
               firstName
@@ -343,7 +340,6 @@ describe('When registering, deactivating, and reactivating a user as a community
       `,
         {
           userId: newUserId,
-          email: newUserEmail,
         },
       );
 

--- a/src/community.admin.deactivate.reactivate.user.test.js
+++ b/src/community.admin.deactivate.reactivate.user.test.js
@@ -350,14 +350,19 @@ describe('When registering, deactivating, and reactivating a user as a community
 
   describe('As a password resetter', async () => {
     var lokka;
-    console.log(newUserId);
-    const token = jwt.sign({ user_id: newUserId, role: 'floods_password_resetter' }, process.env.JWT_SECRET, {expiresIn: '30m', audience: 'postgraphql'});
-    const headers = {
-      Authorization: 'Bearer ' + token,
-    };
-    lokka = new Lokka({
-      transport: new HttpTransport(endpoint, { headers }),
-    });
+
+    beforeAll(async done => {
+      console.log(newUserId);
+      const token = jwt.sign({ user_id: newUserId, role: 'floods_password_resetter' }, process.env.JWT_SECRET, {expiresIn: '30m', audience: 'postgraphql'});
+      const headers = {
+        Authorization: 'Bearer ' + token,
+      };
+      lokka = new Lokka({
+        transport: new HttpTransport(endpoint, { headers }),
+      });
+      done();
+    })
+    
 
     it('should reset the password', async () => {
       const response = await lokka.send(

--- a/src/community.admin.deactivate.reactivate.user.test.js
+++ b/src/community.admin.deactivate.reactivate.user.test.js
@@ -352,7 +352,6 @@ describe('When registering, deactivating, and reactivating a user as a community
     var lokka;
 
     beforeAll(async done => {
-      console.log(newUserId);
       const token = jwt.sign({ user_id: newUserId, role: 'floods_password_resetter' }, process.env.JWT_SECRET, {expiresIn: '30m', audience: 'postgraphql'});
       const headers = {
         Authorization: 'Bearer ' + token,

--- a/src/community.editor.deactivate.reactivate.test.js
+++ b/src/community.editor.deactivate.reactivate.test.js
@@ -169,10 +169,7 @@ describe('When deactivating, and reactivating a user as a community editor', () 
           `
           mutation($userId:Int!, $email:String!) {
             reactivateUser(input: {
-              userId: $userId,
-              email: $email
-              password: "texasfloods"
-              role: "floods_community_editor"
+              userId: $userId
             }) {
               user {
                 firstName
@@ -183,8 +180,7 @@ describe('When deactivating, and reactivating a user as a community editor', () 
           }
         `,
           {
-            userId: newUserId,
-            email: newUserEmail,
+            userId: newUserId
           },
         );
       } catch (e) {

--- a/src/community.editor.deactivate.reactivate.test.js
+++ b/src/community.editor.deactivate.reactivate.test.js
@@ -167,7 +167,7 @@ describe('When deactivating, and reactivating a user as a community editor', () 
       try {
         const response = await lokka.send(
           `
-          mutation($userId:Int!, $email:String!) {
+          mutation($userId:Int!) {
             reactivateUser(input: {
               userId: $userId
             }) {

--- a/src/community.editor.self.deactivate.reactivate.test.js
+++ b/src/community.editor.self.deactivate.reactivate.test.js
@@ -162,12 +162,9 @@ describe('When registering, deactivating, and reactivating a user', () => {
     it('should reactivate the user', async () => {
       const response = await lokka.send(
         `
-        mutation($userId:Int!, $email:String!) {
+        mutation($userId:Int!) {
           reactivateUser(input: {
-            userId: $userId,
-            email: $email
-            password: "texasfloods"
-            role: "floods_community_editor"
+            userId: $userId
           }) {
             user {
               firstName
@@ -179,7 +176,6 @@ describe('When registering, deactivating, and reactivating a user', () => {
       `,
         {
           userId: newUserId,
-          email: newUserEmail,
         },
       );
 

--- a/src/super.admin.user.deactivate.reactivate.test.js
+++ b/src/super.admin.user.deactivate.reactivate.test.js
@@ -214,6 +214,42 @@ describe('When registering, deactivating, and reactivating a user as a super adm
     });
   });
 
+  describe('As a password resetter', async () => {
+    var lokka;
+
+    beforeAll(async done => {
+      const token = jwt.sign({ user_id: newUserId, role: 'floods_password_resetter' }, process.env.JWT_SECRET, {expiresIn: '30m', audience: 'postgraphql'});
+      const headers = {
+        Authorization: 'Bearer ' + token,
+      };
+      lokka = new Lokka({
+        transport: new HttpTransport(endpoint, { headers }),
+      });
+      done();
+    })
+    
+
+    it('should reset the password', async () => {
+      const response = await lokka.send(
+        `
+        mutation ($password:String!){
+          resetPassword(input: {
+            newPassword: $password
+          }) {
+            jwtToken
+          }
+        }
+      `,
+        {
+          password: newUserPassword,
+        },
+      );
+
+      console.log(response);
+      expect(response.jwtToken).not.toBeNull();
+    });
+  });
+
   describe('As the reactivated user', async () => {
     var lokka;
 

--- a/src/super.admin.user.deactivate.reactivate.test.js
+++ b/src/super.admin.user.deactivate.reactivate.test.js
@@ -189,12 +189,9 @@ describe('When registering, deactivating, and reactivating a user as a super adm
     it('should reactivate the user', async () => {
       const response = await lokka.send(
         `
-        mutation($userId:Int!, $email:String!) {
+        mutation($userId:Int!) {
           reactivateUser(input: {
-            userId: $userId,
-            email: $email
-            password: "texasfloods"
-            role: "floods_community_editor"
+            userId: $userId
           }) {
             user {
               firstName
@@ -206,7 +203,6 @@ describe('When registering, deactivating, and reactivating a user as a super adm
       `,
         {
           userId: newUserId,
-          email: newUserEmail,
         },
       );
 

--- a/src/super.admin.user.deactivate.reactivate.test.js
+++ b/src/super.admin.user.deactivate.reactivate.test.js
@@ -1,6 +1,7 @@
 import HttpTransport from 'lokka-transport-http';
 import Lokka from 'lokka';
 import uuidv4 from 'uuid';
+import jwt from 'jsonwebtoken';
 import { endpoint } from './endpoints';
 
 const anonLokka = new Lokka({ transport: new HttpTransport(endpoint) });


### PR DESCRIPTION
I refactored the reactivate user function to only use an ID instead of also requiring an email and password. The password used for reactivation is randomly generated by postgres. I also updates the tests to use the password resetter functionality to be able to test logging in again as the test suite does not know the randomly reset password. This matches with the flow for reactivating users through the dashboard (reactivate, send reset email).